### PR TITLE
Vyřešit problém s automatickou inicializací SQLite databáze v Docker Compose prostředí.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,18 @@ COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma
 COPY --from=builder /app/node_modules/@prisma ./node_modules/@prisma
 COPY --from=builder /app/node_modules/@libsql ./node_modules/@libsql
 
+# Copy Prisma CLI and dependencies for migrations
+COPY --from=builder /app/node_modules/prisma ./node_modules/prisma
+COPY --from=builder /app/node_modules/.bin ./node_modules/.bin
+
+# Copy startup script
+COPY scripts/docker-entrypoint.sh /app/docker-entrypoint.sh
+
 # Create directory for database and set permissions
 RUN mkdir -p /app/data && chown -R nextjs:nodejs /app/data
+
+# Make entrypoint script executable
+RUN chmod +x /app/docker-entrypoint.sh
 
 USER nextjs
 
@@ -55,5 +65,5 @@ EXPOSE 3000
 
 ENV PORT=3000
 
-# Start the application
-CMD ["node", "server.js"]
+# Use the startup script as entrypoint
+ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Comprehensive documentation is available in the `docs/` directory:
 - **[Agent Creation Guide](docs/CREATING_AGENTS.md)** - How to create custom agents
 - **[Database Status Report](DATABASE_STATUS.md)** - Database schema and verification results
 - **[Deployment Guide](docs/DEPLOYMENT.md)** - Docker and production deployment
+- **[Docker Database Setup](docs/DOCKER_DATABASE_SETUP.md)** - Automatic database initialization in Docker
 
 ---
 
@@ -306,8 +307,10 @@ PORT=3000
 
 ### Docker Deployment
 
+The application includes automatic database initialization when using Docker Compose:
+
 ```bash
-# Build and start containers
+# Build and start containers (database auto-initializes on first run)
 docker-compose up -d
 
 # View logs
@@ -315,7 +318,14 @@ docker-compose logs -f
 
 # Stop containers
 docker-compose down
+
+# Reset database (remove volumes)
+docker-compose down -v
 ```
+
+**Note**: The database is automatically initialized on first startup. No manual migration steps required!
+
+For detailed information about the Docker database setup, see [docs/DOCKER_DATABASE_SETUP.md](docs/DOCKER_DATABASE_SETUP.md).
 
 ---
 

--- a/docs/DOCKER_DATABASE_SETUP.md
+++ b/docs/DOCKER_DATABASE_SETUP.md
@@ -1,0 +1,196 @@
+# Docker Database Setup
+
+## Automatic Database Initialization
+
+This document describes how the SQLite database is automatically initialized when running the application with Docker Compose.
+
+## Problem Solved
+
+Previously, when running the application with `docker-compose up`, the application would fail with:
+```
+SQLITE_ERROR: no such table: main.Agent
+```
+
+This occurred because the Prisma migrations were not being run automatically during container startup.
+
+## Solution
+
+The application now uses a startup script (`scripts/docker-entrypoint.sh`) that automatically:
+
+1. ✅ Checks for the DATABASE_URL environment variable
+2. ✅ Creates the database directory if it doesn't exist
+3. ✅ Runs Prisma migrations (`prisma migrate deploy`)
+4. ✅ Falls back to `prisma db push` if migrations fail
+5. ✅ Verifies that tables were created successfully
+6. ✅ Starts the Next.js application
+
+## How It Works
+
+### Startup Script (`scripts/docker-entrypoint.sh`)
+
+The entrypoint script performs these steps in order:
+
+```bash
+🚀 Starting Agent Verse application...
+📁 Database URL: file:/app/data/production.db
+📂 Ensuring database directory exists: /app/data
+🆕 Database file does not exist, will be created during migration
+🔄 Running Prisma migrations...
+✅ Prisma migrations completed successfully
+🔍 Verifying database tables...
+✅ Database tables verified
+🎯 Starting Next.js application...
+```
+
+### Dockerfile Changes
+
+The Dockerfile now:
+- Copies the Prisma CLI and dependencies needed for running migrations
+- Copies the `docker-entrypoint.sh` startup script
+- Sets the script as executable
+- Uses the script as the container's ENTRYPOINT
+
+### Docker Compose Configuration
+
+The `docker-compose.yml` configures:
+- A persistent volume (`db-data`) mounted at `/app/data` for database persistence
+- Environment variable `DATABASE_URL=file:/app/data/production.db`
+- Proper permissions for the database directory
+
+## Usage
+
+### Starting the Application
+
+Simply run:
+```bash
+docker-compose up
+```
+
+The database will be automatically initialized on first startup. Subsequent starts will use the existing database.
+
+### Rebuilding After Schema Changes
+
+If you modify the Prisma schema:
+
+1. Create a new migration locally:
+   ```bash
+   npx prisma migrate dev --name your_migration_name
+   ```
+
+2. Rebuild the Docker image:
+   ```bash
+   docker-compose build
+   ```
+
+3. Restart the application:
+   ```bash
+   docker-compose up
+   ```
+
+The new migrations will be automatically applied on startup.
+
+### Resetting the Database
+
+To completely reset the database:
+
+```bash
+# Stop and remove containers and volumes
+docker-compose down -v
+
+# Start fresh
+docker-compose up
+```
+
+This will create a new database from scratch.
+
+## Database Persistence
+
+The database file is stored in a Docker volume named `db-data`, which persists between container restarts. This means:
+
+- ✅ Data is preserved when stopping/starting containers
+- ✅ Data is preserved when rebuilding images
+- ❌ Data is lost only when explicitly running `docker-compose down -v`
+
+## Troubleshooting
+
+### "Migration failed" error
+
+If you see migration errors:
+1. Check that your `prisma/schema.prisma` is valid
+2. Ensure all migration files are included in the Docker image
+3. Try running `docker-compose down -v` to start fresh
+
+### "Permission denied" error
+
+If you see permission errors:
+1. Ensure the volume mount is correctly configured in `docker-compose.yml`
+2. Check that the user has write permissions to the mounted volume
+3. The Dockerfile creates the directory with proper permissions for the `nextjs` user
+
+### Tables not being created
+
+If tables aren't created but no errors appear:
+1. Check the container logs: `docker-compose logs app`
+2. Verify the DATABASE_URL is correctly set
+3. Ensure Prisma migrations exist in `prisma/migrations/`
+
+## Environment Variables
+
+Required environment variables for database:
+
+- `DATABASE_URL`: Path to the SQLite database file (default: `file:/app/data/production.db`)
+
+Optional environment variables:
+
+- `PORT`: Application port (default: 3000)
+- `ANTHROPIC_API_KEY`: API key for Anthropic Claude
+- `NEXTAUTH_SECRET`: Secret for NextAuth.js
+- `NEXTAUTH_URL`: Base URL for authentication
+
+## Technical Details
+
+### Migration Strategy
+
+The startup script uses a two-tier approach:
+
+1. **Primary**: `prisma migrate deploy`
+   - Applies all pending migrations from `prisma/migrations/`
+   - Safe for production
+   - Preserves data
+
+2. **Fallback**: `prisma db push --accept-data-loss`
+   - Used if no migrations exist or migrate deploy fails
+   - Syncs schema directly to database
+   - Useful for development
+
+### File Structure
+
+```
+agent-verse-via-agent/
+├── Dockerfile                          # Multi-stage build with Prisma support
+├── docker-compose.yml                  # Service definition with volume mounts
+├── scripts/
+│   └── docker-entrypoint.sh           # Database initialization script
+├── prisma/
+│   ├── schema.prisma                   # Database schema
+│   └── migrations/                     # Migration files
+│       ├── 20260212115750_init/
+│       ├── 20260213004146_add_agentverse_fields/
+│       └── ...
+└── data/                               # Database directory (in container)
+    └── production.db                   # SQLite database file
+```
+
+## Best Practices
+
+1. **Always commit migrations**: Ensure migration files are checked into git
+2. **Test locally first**: Run migrations locally before deploying
+3. **Use volumes for persistence**: Never store databases in container layers
+4. **Monitor startup logs**: Check that migrations succeed
+5. **Backup data**: Regularly backup the database volume
+
+## References
+
+- [Prisma Migrate Documentation](https://www.prisma.io/docs/concepts/components/prisma-migrate)
+- [Docker Compose Volumes](https://docs.docker.com/compose/compose-file/compose-file-v3/#volumes)
+- [Next.js Docker Deployment](https://nextjs.org/docs/deployment#docker-image)

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+set -e
+
+echo "🚀 Starting Agent Verse application..."
+
+# Check if DATABASE_URL is set
+if [ -z "$DATABASE_URL" ]; then
+  echo "⚠️  WARNING: DATABASE_URL is not set, using default"
+  export DATABASE_URL="file:/app/data/production.db"
+fi
+
+echo "📁 Database URL: $DATABASE_URL"
+
+# Extract database file path from DATABASE_URL (remove file: prefix)
+DB_FILE=$(echo "$DATABASE_URL" | sed 's/file://')
+DB_DIR=$(dirname "$DB_FILE")
+
+# Ensure database directory exists and has proper permissions
+echo "📂 Ensuring database directory exists: $DB_DIR"
+mkdir -p "$DB_DIR"
+
+# Check if database file exists
+if [ -f "$DB_FILE" ]; then
+  echo "✅ Database file exists: $DB_FILE"
+else
+  echo "🆕 Database file does not exist, will be created during migration"
+fi
+
+# Run Prisma migrations
+echo "🔄 Running Prisma migrations..."
+if npx prisma migrate deploy; then
+  echo "✅ Prisma migrations completed successfully"
+else
+  echo "⚠️  Prisma migrate deploy failed, trying prisma db push..."
+  if npx prisma db push --accept-data-loss; then
+    echo "✅ Database schema pushed successfully"
+  else
+    echo "❌ Failed to initialize database schema"
+    exit 1
+  fi
+fi
+
+# Verify database tables exist
+echo "🔍 Verifying database tables..."
+if npx prisma db execute --stdin <<EOF
+SELECT name FROM sqlite_master WHERE type='table' AND name='Agent';
+EOF
+then
+  echo "✅ Database tables verified"
+else
+  echo "⚠️  Could not verify tables, but continuing..."
+fi
+
+# Start the application
+echo "🎯 Starting Next.js application..."
+exec node server.js


### PR DESCRIPTION
Vyřešit problém s automatickou inicializací SQLite databáze v Docker Compose prostředí.

PROBLÉM: Aplikace hází chybu 'SQLITE_ERROR: no such table: main.Agent' při spuštění přes docker-compose.

POTŘEBNÉ ÚPRAVY:
1. Upravit Dockerfile nebo docker-compose.yml tak, aby se automaticky spustily Prisma migrace při startu kontejneru
2. Přidat startup script který:
   - Zkontroluje existenci databáze
   - Spustí 'prisma db push' nebo 'prisma migrate deploy' pro vytvoření tabulek
   - Teprve poté spustí hlavní aplikaci
3. Zajistit, aby se databázový soubor vytvářel do správného adresáře s persistence přes volumes
4. Otestovat, že po 'docker-compose up' funguje aplikace bez manuálního zásahu

VÝSTUP: Funkční aplikace spustitelná jedním příkazem 'docker-compose up' bez nutnosti manuální inicializace databáze.