### PR TITLE
Zjisti proč při Docker build selhává Prisma s chybějící DATABASE_URL proměnnou, i když by měla být dostupná z docker-com

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,10 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
+# Set dummy DATABASE_URL for Prisma client generation during build
+# The real DATABASE_URL will be provided at runtime
+ENV DATABASE_URL="file:./build-dummy.db"
+
 # Generate Prisma client
 RUN npx prisma generate
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "predev": "npm run db:init",
     "dev": "next dev",
-    "prebuild": "npm run db:init && node scripts/generate-build-info.js",
+    "prebuild": "node scripts/generate-build-info.js",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,6 +7,7 @@ generator client {
 
 datasource db {
   provider = "sqlite"
+  url      = env("DATABASE_URL")
 }
 
 model User {


### PR DESCRIPTION
Zjisti proč při Docker build selhává Prisma s chybějící DATABASE_URL proměnnou, i když by měla být dostupná z docker-compose.yml nebo .env souboru. Podívej se na:
1. docker-compose.yml - jak se předávají environment proměnné do build kontextu
2. Dockerfile - zda build stage má přístup k env proměnným
3. scripts/init-db.ts - zda správně načítá DATABASE_URL
4. .env.example a možné chybějící .env soubor

Cíl: Build by neměl potřebovat DATABASE_URL v build time, nebo by ji měl správně dostat z runtime prostředí.