### PR TITLE
Deploy selhává s chybou 'Cannot find module valibot'. Valibot je chybějící dependency vyžadované Prisma. Úkol:

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-hook-form": "^7.71.1",
+        "valibot": "^1.2.0",
         "zod": "^4.3.6"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-hook-form": "^7.71.1",
+    "valibot": "^1.2.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Deploy selhává s chybou 'Cannot find module valibot'. Valibot je chybějící dependency vyžadované Prisma. Úkol:

1. Přidej 'valibot' do package.json dependencies (nejnovější verzi)
2. Spusť npm install pro aktualizaci lock file
3. Zkontroluj že všechny Prisma dependencies jsou správně nainstalované
4. Otestuj že build funguje lokálně
5. Commituj změny s popisem 'Add missing valibot dependency for Prisma'

Chyba nastává při Prisma migrate deploy, kdy @prisma/dev package vyžaduje valibot modul který není v dependencies.