### PR TITLE
AgentVerse Docker Fix Task:

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,9 @@ COPY --from=builder /app/node_modules/pg-* ./node_modules/
 COPY --from=builder /app/node_modules/prisma ./node_modules/prisma
 COPY --from=builder /app/node_modules/.bin ./node_modules/.bin
 
+# Copy valibot - required by Prisma 7 at runtime
+COPY --from=builder /app/node_modules/valibot ./node_modules/valibot
+
 # Copy startup script
 COPY scripts/docker-entrypoint.sh /app/docker-entrypoint.sh
 

--- a/docs/CHANGES_2026-02-15.md
+++ b/docs/CHANGES_2026-02-15.md
@@ -98,3 +98,82 @@ Build process tested successfully:
 - `docker-compose.yml` - Docker Compose configuration
 - `package.json` - Build scripts
 - `docs/DEVELOPMENT.md` - Developer documentation
+
+---
+
+## Docker Valibot Dependency Fix
+
+### Summary
+Fixed "Cannot find module 'valibot'" error when running the application via Docker Compose by adding the valibot module to the Docker image.
+
+### Problem
+When running `docker-compose up`, the application would fail to start with the error:
+```
+Error: Cannot find module 'valibot'
+```
+
+This occurred because:
+1. Prisma 7 has a runtime dependency on the `valibot` package for validation
+2. The Dockerfile uses a multi-stage build with Next.js standalone mode
+3. The runner stage manually copies specific node_modules directories
+4. The valibot module was not included in the manual copy list
+5. At runtime, when Prisma attempted to use valibot, the module was missing
+
+### Root Cause
+The `@prisma/dev` package (part of Prisma 7) imports and uses valibot for schema validation:
+- Used in state management and configuration validation
+- Required at runtime, not just build time
+- Not automatically included by Next.js standalone bundler since it's a Prisma dependency
+
+### Solution
+Added valibot to the list of manually copied node_modules in the Dockerfile runner stage (line 64-65):
+
+```dockerfile
+# Copy valibot - required by Prisma 7 at runtime
+COPY --from=builder /app/node_modules/valibot ./node_modules/valibot
+```
+
+### Changes Made
+
+#### Files Modified
+- `Dockerfile` - Added valibot module copy in runner stage
+- `docs/CHANGES_2026-02-15.md` - Documented the fix
+
+### Technical Details
+
+The Dockerfile uses a three-stage build:
+1. **deps stage**: Installs all dependencies via `npm ci`
+2. **builder stage**: Builds the Next.js application with Prisma generation
+3. **runner stage**: Creates minimal production image with only required files
+
+In the runner stage, the Dockerfile manually copies specific node_modules to keep the image size small. The following modules are copied for Prisma and PostgreSQL support:
+- `.prisma` - Generated Prisma client
+- `@prisma` - Prisma runtime packages (including `@prisma/dev` which requires valibot)
+- `prisma` - Prisma CLI for migrations
+- `pg` and `pg-*` - PostgreSQL client libraries
+- `valibot` - **NEW**: Validation library required by Prisma 7
+
+### Verification
+
+To verify the fix works:
+
+```bash
+# Build and start with Docker Compose
+docker compose up --build
+
+# Expected result: Application starts successfully without module errors
+# The app should be accessible at http://localhost:3000
+```
+
+### Impact
+- ✅ Fixes "Cannot find module 'valibot'" runtime error
+- ✅ Enables successful Docker Compose deployment
+- ✅ Minimal impact on image size (valibot is a small package)
+- ✅ No changes to application code required
+- ✅ Compatible with existing deployment workflows
+
+### Related Files
+- `Dockerfile` - Docker configuration (modified)
+- `package.json` - Already includes valibot dependency
+- `docker-compose.yml` - Docker Compose configuration (no changes needed)
+- `scripts/docker-entrypoint.sh` - Startup script (no changes needed)


### PR DESCRIPTION
AgentVerse Docker Fix Task:

1. Analyze the current Docker Compose setup in the repository
2. Test running 'docker-compose up' to reproduce the 'Cannot find module valibot' error
3. Fix the missing valibot dependency by:
   - Adding valibot to package.json dependencies if missing
   - Ensuring proper npm install in Dockerfile
   - Updating Docker Compose configuration if needed
4. Verify the application starts successfully with docker-compose
5. Test basic functionality to ensure the fix works
6. Document any changes made in commit messages

Goal: Make AgentVerse fully runnable via docker-compose without module errors.

Acceptance Criteria:
- docker-compose up runs without 'Cannot find module' errors
- Application starts and is accessible
- All dependencies are properly installed in containers